### PR TITLE
Updated Harmony refs for Harmony2.0

### DIFF
--- a/Patching/GamePatcher.cs
+++ b/Patching/GamePatcher.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using System;
 using System.Collections.Generic;
@@ -11,7 +11,7 @@ namespace PurrplingCore.Patching
     {
         private readonly IMonitor monitor;
         private readonly bool paranoid;
-        private readonly HarmonyInstance harmony;
+        private readonly Harmony harmony;
         private readonly List<MethodBase> knownConflictedPatches;
 
         public GamePatcher(string uid, IMonitor monitor, bool paranoid = true)
@@ -19,7 +19,7 @@ namespace PurrplingCore.Patching
             this.monitor = monitor;
             this.paranoid = paranoid;
             this.knownConflictedPatches = new List<MethodBase>();
-            this.harmony = HarmonyInstance.Create(uid);
+            this.harmony = new Harmony(uid);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace PurrplingCore.Patching
                 .ToArray();
             foreach (var method in methods)
             {
-                Harmony.Patches info = this.harmony.GetPatchInfo(method);
+                HarmonyLib.Patches info = Harmony.GetPatchInfo(method);
 
                 if (info != null && info.Owners.Contains(this.harmony.Id))
                 {
@@ -98,14 +98,14 @@ namespace PurrplingCore.Patching
 
         public class PatchedMethod
         {
-            public PatchedMethod(MethodBase method, Harmony.Patches patchInfo)
+            public PatchedMethod(MethodBase method, HarmonyLib.Patches patchInfo)
             {
                 this.Method = method;
                 this.PatchInfo = patchInfo;
             }
 
             public MethodBase Method { get; }
-            public Harmony.Patches PatchInfo { get; }
+            public HarmonyLib.Patches PatchInfo { get; }
         }
     }
 }

--- a/Patching/IPatch.cs
+++ b/Patching/IPatch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 
 namespace PurrplingCore.Patching
@@ -7,6 +7,6 @@ namespace PurrplingCore.Patching
     {
         string Name { get; }
         bool Applied { get; }
-        void Apply(HarmonyInstance harmony, IMonitor monitor);
+        void Apply(Harmony harmony, IMonitor monitor);
     }
 }

--- a/Patching/Patch.cs
+++ b/Patching/Patch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using System;
 
@@ -17,7 +17,7 @@ namespace PurrplingCore.Patching
         public abstract string Name { get; }
         public bool Applied { get; private set; }
 
-        protected abstract void Apply(HarmonyInstance harmony);
+        protected abstract void Apply(Harmony harmony);
 
         /// <summary>
         /// Setup and apply game patch
@@ -25,7 +25,7 @@ namespace PurrplingCore.Patching
         /// <param name="harmony"></param>
         /// <param name="monitor"></param>
         /// <exception cref="Exception">Any exception raised while appling game patch</exception>
-        public void Apply(HarmonyInstance harmony, IMonitor monitor)
+        public void Apply(Harmony harmony, IMonitor monitor)
         {
             if (Instance == null)
             {


### PR DESCRIPTION
Updates the Harmony references to work with Harmony 2.0/SMAPI 3.12 as advised [here](https://stardewvalleywiki.com/Modding:Migrate_to_Harmony_2.0).